### PR TITLE
[deepspeed/autotuner] Fix for timer for gas > 1

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2065,6 +2065,8 @@ class DeepSpeedEngine(Module):
         record = self.is_gradient_accumulation_boundary() and \
             self.flops_profiler_enabled() and \
                 (self.global_steps >= self.flops_profiler_profile_step())
+        if not record:
+            return
         for name in timer_names:
             self.timers(name).stop(record=record)
 

--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -41,6 +41,8 @@ class SynchronizedWallClockTimer:
 
         def start(self):
             """Start the timer."""
+            if self.started_:
+                return
             assert not self.started_, f"{self.name_} timer has already been started"
             self.start_event = torch.cuda.Event(enable_timing=True)
             self.start_event.record()


### PR DESCRIPTION
The current implementation stops the timer even for non gradient accumulation boundary steps which artificially inflates the throughput when gas > 1.